### PR TITLE
Env-file for docker compose & documentation

### DIFF
--- a/logaggregation/EFK/docker-compose.yml
+++ b/logaggregation/EFK/docker-compose.yml
@@ -6,8 +6,8 @@ elasticsearch:
     - "9300"
 fluentd:
   build: ./fluentd
-  environment:
-    - FLUENTD_CONF=td-agent-aggregator.conf
+  env_file:
+    - ./fluentd/fluentd.properties
   volumes:
     - ./fluentd/config:/fluentd/etc
     - ./fluentd/certs:/fluentd/certs

--- a/logaggregation/EFK/fluentd/config/td-agent-aggregator.conf
+++ b/logaggregation/EFK/fluentd/config/td-agent-aggregator.conf
@@ -5,32 +5,30 @@
 #secure input source from log shippers
 <source>
 	type secure_forward
-	shared_key AllYourBaseAreBelongToUs
-	self_hostname logserver.akai
+	shared_key "#{ENV['FLUENTD_SHARED_KEY']}"
+	self_hostname "#{ENV['FLUENTD_HOSTNAME']}"
 	#cert_auto_generate yes
 
 	ca_cert_path /fluentd/certs/ca_cert.pem
 	ca_private_key_path /fluentd/certs/ca_key.pem
-	ca_private_key_passphrase AllYourBaseAreBelongToUs
+	ca_private_key_passphrase "#{ENV['FLUENTD_PRIVATE_KEY_PASSPHRASE']}"
 
 	secure true
 
 	#for authentication
 	authentication yes
 	<user>
-		username akai4life
-		password squirrel
+		username "#{ENV['FLUENTD_SECURE_USERNAME']}"
+		password "#{ENV['FLUENTD_SECURE_PASSWORD']}"
 	</user>
 
-	#allow only known hosts
+# Enabling this will allow only known hosts & user combinations
 #	allow_anonymous_source no
 #	<client>
 #		network 172.18.20.97
 #		users akai4life
 		#also can use 'host akai.hl-network.adns.de'
 #	</client>
-
-	flush_interval 1s
 </source>
 
 ####
@@ -48,7 +46,8 @@
     </store>
     <store>
     #All events pushed to stdout while fluentd is running as a service will be
-    #appended to the td-agent log
+    #appended to the td-agent log if started as service or to the console output
+		#if started with docker-compose
         type stdout
     </store>
 </match>
@@ -63,6 +62,6 @@
 #tag by previously enumerated filters and match nodes.
 <match **>
     type rewrite_tag_filter
-    rewriterule1 sourceProject ^AKA-I$ internal.akai
+    rewriterule1 sourceProject ^yourProjectName$ internal.yourProjectName
     rewriterule2 message .* clear
 </match>

--- a/logaggregation/EFK/fluentd/fluentd.properties
+++ b/logaggregation/EFK/fluentd/fluentd.properties
@@ -1,0 +1,7 @@
+FLUENTD_CONF=td-agent-aggregator.conf
+### Remember to change these to match the values accepted by the aggregator
+FLUENTD_SHARED_KEY=AllYourBaseAreBelongToUs
+FLUENTD_PRIVATE_KEY_PASSPHRASE=AllYourBaseAreBelongToUs
+FLUENTD_HOSTNAME=fluentd.haufe.de
+FLUENTD_SECURE_USERNAME=username
+FLUENTD_SECURE_PASSWORD=password

--- a/logaggregation/FluentDShipper/README.md
+++ b/logaggregation/FluentDShipper/README.md
@@ -21,6 +21,7 @@ Steps to set up the shipper:
 3. Modify the `/config/td-agent-shipper.conf` file according to the needs of the log source to be monitored.
   *  By default the shipper is monitoring a log file called file.log that is found on the mountable volume `/fluentd/log/` and are issued with the tag set via `FLUENTD_TAIL_TAG`
   * To make sure that it would work straight out of the box there is a `<match default.**>` that rewrites the tags of log messages to tags that would be matched by the sample provided filter and output match tag. Feel free to change the tags and overall message pipeline as needed.
+  * Be sure to also read up on the documentation for each filter to know the default values for certain parameters so that you can avoid unwanted behavior - [default values](../README.md#beware-of-default-values)
 
 Build locally with `docker build --tag=<name_your_shipper> .` in the FluentDShipper folder.
 

--- a/logaggregation/README.md
+++ b/logaggregation/README.md
@@ -31,6 +31,8 @@ https://github.com/tagomoris/fluent-plugin-secure-forward#using-private-ca-file-
 
 * Change credentials for authentication in config file. Authentication can also be disabled by setting `authentication` to `false` or `no`
 
+* __Very important!__: This sample allows you to filter out unwanted messages via the `<match **>` tag at the bottom that uses the `rewrite-tag-filter` to determine what log messages go through and what messages are thrown away. In this example it looks in the `sourceProject` field and if it contains a specific value then it is re-tagged with the `internal` prefix and re-emitted internally. All messages with `internal` as the tag prefix are automatically caught by the `<match internal.**>` tag and sent to elasticsearch. Feel free to remove or modify this mechanism.
+
 ### Beware of default values
  Be aware that each plugin used has default values for certain configurable parameters and to avoid unwanted behavior or to tweak the system optimally you should refer to the github pages of the individual plugin.
 

--- a/logaggregation/README.md
+++ b/logaggregation/README.md
@@ -31,6 +31,18 @@ https://github.com/tagomoris/fluent-plugin-secure-forward#using-private-ca-file-
 
 * Change credentials for authentication in config file. Authentication can also be disabled by setting `authentication` to `false` or `no`
 
+### Beware of default values
+ Be aware that each plugin used has default values for certain configurable parameters and to avoid unwanted behavior or to tweak the system optimally you should refer to the github pages of the individual plugin.
+
+ A good example is the elasticsearch plugin that by default has buffering enabled with a flush_interval of 60sec so if you were wondering why your log messages are popping up in elasticsearch with a delay...
+
+So be sure to RTM:
+ - [fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch)
+ - [fluent-plugin-secure-forward](https://github.com/tagomoris/fluent-plugin-secure-forward)
+ - [fluent-plugin-rewrite-tag-filter](https://github.com/fluent/fluent-plugin-rewrite-tag-filter)
+
+
+
 ### 3. Start it up :v:
 
 Run `docker-compose up` in `/ELK/` and once finished you can access Kibana on [http://localhost:80](http://localhost:80) and login with the credentials you created in the setup phase.


### PR DESCRIPTION
Modified fluentd aggregator configuration file to use environment variables provided via an env-file set in the docker-compose.yml and extended documentation with important information to avoid misunderstood behavior.